### PR TITLE
Add CI workflow to lint mixin with mixtool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: "ubuntu-latest"
+    container:
+      image: "golang"
+    steps:
+      - name: "Checkout code"
+        uses: "actions/checkout@v3"
+
+      - name: "Install mixtool"
+        id: "install-mixtool"
+        run: "go install github.com/monitoring-mixins/mixtool/cmd/mixtool@main"
+
+      - name: "Run mixtool"
+        id: "run-mixtool"
+        run: "mixtool lint mixin.libsonnet"


### PR DESCRIPTION
Proof of failure when linting exists: https://github.com/jdbaldry/haproxy-mixin/actions/runs/3985906490/jobs/6833839697

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>